### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Create a MapRoulette challenge from a GeoJSON file or gist with little effort!
 
-Let me explain how this works with an example. OSM user `bitnapper` proposed a challenge for adding multilingual names to places in Ireland a while ago. If I understand her or his request correctly, these are OSM `place` nodes that have a `name` tag but perhaps not a `name:ga` tag for the Gaelic name. (I am making the assumption that `name` will always hold the English name. That may not be accurate.) These nodes can be isolated with an Overpass Turbo query [like so](http://overpass-turbo.eu/s/eHY): 
+Let me explain how this works with an example. OSM user `bitnapper` proposed a challenge for adding multilingual names to places in Ireland a while ago. If I understand her or his request correctly, these are OSM `place` nodes that have a `name` tag but perhaps not a `name:ga` tag for the Irish name. (`name` will hold the local name, which is nearly always the English name.) These nodes can be isolated with an Overpass Turbo query [like so](http://overpass-turbo.eu/s/eHY): 
 
 <a data-flickr-embed="true"  href="https://www.flickr.com/photos/rhodes/25368276726/" title="Untitled"><img src="https://farm2.staticflickr.com/1560/25368276726_90a2b0417f_z.jpg" width="640" height="185" alt="Untitled"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 


### PR DESCRIPTION
(i) Within Ireland the language is called "Irish" not "Gaelic". However within UK (and maybe USA?) people call it "Gaelic". Using the general OSM principle of "local community usage", it's probably better to call it "Irish". ;)

(ii) Clarified how the `name` tag is used. It's basically the local name, which is English, _except_ for places in the [Gaeltach](https://en.wikipedia.org/wiki/Gaeltacht), the legally defined Irish speaking areas in a few patches along the west coast. In those areas, `name` is in Irish, with `name:en` for it in English. This is not without controversy. Dingle, on the south west coast, is a large tourist destination, and in the Gaeltacht. To aid navigation, locals have been spray painting the English name on sign posts ([read more](https://en.wikipedia.org/wiki/Dingle#Name)).
